### PR TITLE
Stay on the current page when logging in or out

### DIFF
--- a/debug_toolbar_user_switcher/views.py
+++ b/debug_toolbar_user_switcher/views.py
@@ -32,7 +32,9 @@ def login(request, **kwargs):
     user.backend = settings.AUTHENTICATION_BACKENDS[0]
     auth.login(request, user)
 
-    return HttpResponseRedirect(request.POST.get("next", "/"))
+    return HttpResponseRedirect(
+        request.POST.get("next", request.META.get("HTTP_REFERER", "/")),
+    )
 
 
 @csrf_exempt
@@ -40,4 +42,6 @@ def login(request, **kwargs):
 @debug_required
 def logout(request):
     django_logout(request)
-    return HttpResponseRedirect(request.POST.get("next", "/"))
+    return HttpResponseRedirect(
+        request.POST.get("next", request.META.get("HTTP_REFERER", "/")),
+    )


### PR DESCRIPTION
I've found that the majority of the time I use the user-switcher panel this is what I want. Especially as we're not actually running through the site's real login logic, it's relatively unlikely that the previous behaviour was correctly matching that anyway.