### PR TITLE
Update supported versions to reflect state of the world and declare new version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,8 @@ references:
   version-matrix: &version-matrix
     matrix:
       parameters:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        django-version: ["2.2", "3.0", "3.1", "3.2", "4.0"]
-      exclude:
-        - python-version: "3.6"
-          django-version: "4.0"
-        - python-version: "3.7"
-          django-version: "4.0"
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["2.2", "3.0", "3.1", "3.2", "4.0", "5.0"]
 
 executors:
   python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-debug-toolbar-user-switcher"
-version = "2.2.0"
+version = "2.3.0"
 description = "Panel for the Django Debug toolbar to quickly switch between users."
 authors = ["Thread Engineering <tech@thread.com>"]
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-django = ">=2.2,<5"
-django-debug-toolbar = ">=2,<4"
+python = "^3.8"
+django = ">=2.2,<6"
+django-debug-toolbar = ">=2,<5"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
The `<5` qualifier is preventing users from upgrading to Django 5. 

This relaxes the constraint to `<6` and generally reflects the state of the world with upward versions and deprecated Python versions.

Not making it a breaking major as I don't think dropping out of support python versions counts (otherwise we're doing a major a year for everything by definition).
